### PR TITLE
Add demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An OBS plugin that allows you to remove the background from your video source in
 
 [**⬇️ Download Latest Release**](https://obs-backgroundremoval-lite.kaito.tokyo/)
 
+## Demo
+
+![Demo](docs/src/pages/demo.gif)
+
 ---
 
 ## 🌟 Features

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# Background Removal Lite
+# Live Background Removal Lite
 
 An OBS plugin that allows you to remove the background from your video source in real-time, without the need for a green screen.
 
 [**⬇️ Download Latest Release**](https://obs-backgroundremoval-lite.kaito.tokyo/)
 
-## Demo
+## 📸 Demo
 
-![Demo](docs/src/pages/demo.gif)
+<div align="center">
+
+<img src="docs/src/pages/demo.gif" alt="Background Removal Lite Demo" width="480" style="border:1px solid #ccc; border-radius:8px; box-shadow:0 2px 8px #0002;">
+
+<p style="margin-top:8px; color:#666; font-size:90%;">
+  <em>
+    The plugin removes a cluttered room background, revealing a gray color source set behind in OBS.
+  </em>
+</p>
+
+</div>
 
 ---
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -15,6 +15,19 @@ const tagName = release.tag_name;
     detect and remove the background, leaving you with a clean and professional
     look.
   </p>
+  <div style="display: flex; flex-direction: column; align-items: center; margin: 2em 0 2em 0;">
+    <img
+      src="/demo.gif"
+      alt="Background Removal Lite Demo"
+      width="480"
+      style="border:1px solid #ccc; border-radius:8px; box-shadow:0 2px 8px #0002;"
+    />
+    <p style="margin-top:8px; color:#666; font-size:90%;">
+      <em>
+        The plugin removes a cluttered room background, revealing a gray color source set behind in OBS.
+      </em>
+    </p>
+  </div>
   <div class="links">
     <a
       href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-windows-x64.zip`


### PR DESCRIPTION
Added a demo GIF to the README to visually showcase the plugin's functionality. The image is stored at docs/src/pages/demo.gif and is now referenced in the new Demo section.