### PR TITLE
Update demo GIF path and download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An OBS plugin that allows you to remove the background from your video source in real-time, without the need for a green screen.
 
-[**⬇️ Download Latest Release**](https://live-backgroundremoval-lite.kaito.tokyo/)
+[**⬇️ Download Latest Release**](https://kaito-tokyo.github.io/live-backgroundremoval-lite/)
 
 ## 📸 Demo
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { joinURL } from 'ufo';
+import { joinURL } from "ufo";
 import Layout from "../layouts/Layout.astro";
 import { getLatestRelease } from "../lib/github";
 
@@ -11,21 +11,24 @@ const tagName = release.tag_name;
   <h1>Remove your bg, Enrich your stream</h1>
   <p>
     Live Background Removal Lite is a lightweight and easy-to-use plugin for OBS
-    Studio that allows you to remove the background from your webcam feed without
-    the need for a green screen. It uses advanced AI technology to accurately
-    detect and remove the background, leaving you with a clean and professional
-    look.
+    Studio that allows you to remove the background from your webcam feed
+    without the need for a green screen. It uses advanced AI technology to
+    accurately detect and remove the background, leaving you with a clean and
+    professional look.
   </p>
-  <div style="display: flex; flex-direction: column; align-items: center; margin: 2em 0 2em 0;">
+  <div
+    style="display: flex; flex-direction: column; align-items: center; margin: 2em 0 2em 0;"
+  >
     <img
-      src={joinURL(import.meta.env.BASE_URL, 'demo.gif')}
+      src={joinURL(import.meta.env.BASE_URL, "demo.gif")}
       alt="Background Removal Lite Demo"
       width="480"
       style="border:1px solid #ccc; border-radius:8px; box-shadow:0 2px 8px #0002;"
     />
     <p style="margin-top:8px; color:#666; font-size:90%;">
       <em>
-        The plugin removes a cluttered room background, revealing a gray color source set behind in OBS.
+        The plugin removes a cluttered room background, revealing a gray color
+        source set behind in OBS.
       </em>
     </p>
   </div>
@@ -49,6 +52,11 @@ const tagName = release.tag_name;
     <a
       href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/flatpak#readme"
       >Flatpak</a
+    >
+  </div>
+  <div class="links">
+    <a href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/`
+      >GitHub</a
     >
   </div>
 </Layout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { joinURL } from 'ufo';
 import Layout from "../layouts/Layout.astro";
 import { getLatestRelease } from "../lib/github";
 
@@ -17,7 +18,7 @@ const tagName = release.tag_name;
   </p>
   <div style="display: flex; flex-direction: column; align-items: center; margin: 2em 0 2em 0;">
     <img
-      src="/demo.gif"
+      src={joinURL(import.meta.env.BASE_URL, 'demo.gif')}
       alt="Background Removal Lite Demo"
       width="480"
       style="border:1px solid #ccc; border-radius:8px; box-shadow:0 2px 8px #0002;"

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -77,9 +77,11 @@ const tagName = release.tag_name;
     margin-top: 2em;
   }
   .links a {
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 10px 20px;
-    background-color: #4caf50; /* Green */
+    background-color: #4caf50;
     color: white;
     text-align: center;
     text-decoration: none;


### PR DESCRIPTION
This pull request updates the download link in the `README.md` and improves how the demo image is referenced in the documentation site. The changes ensure that URLs are more robust and accurate, especially when the site is deployed to different base paths.

Documentation and URL handling improvements:

* Updated the download link in `README.md` to point to the new GitHub Pages URL for releases.
* Imported the `joinURL` utility from the `ufo` package in `docs/src/pages/index.astro` to help construct URLs that respect the site's base path.
* Changed the demo image source in `docs/src/pages/index.astro` to use `joinURL` with `import.meta.env.BASE_URL`, making the image path robust to different deployment environments.Moved demo.gif to docs/public and updated its reference in index.astro to use joinURL for correct path resolution. Also updated the download link in README.md to the new GitHub Pages URL.