### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "live-backgroundremoval-lite",
     "displayName": "Live Background Removal Lite",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "author": "Kaito Udagawa",
     "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
     "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request includes a minor update to the `buildspec.json` file, incrementing the version number of the project from 1.6.0 to 1.7.0.