### PR TITLE
Update index.astro

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -36,15 +36,15 @@ const tagName = release.tag_name;
   </div>
   <div class="links">
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-windows-x64.zip`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-windows-x64.zip`
       >Windows</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-macos-universal.pkg`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-macos-universal.pkg`
       >Mac</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
       >Ubuntu</a
     >
     <a


### PR DESCRIPTION
This pull request updates the download links on the homepage to use the correct filenames for release assets of the application. The filenames now consistently use the `live-backgroundremoval-lite` prefix, matching the actual release artifacts.

- Updated all platform-specific download links in `index.astro` to use the correct `live-backgroundremoval-lite` prefix in the filenames, ensuring users download the intended files.