### PR TITLE
Update manifests 1.7.0

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -36,15 +36,15 @@ const tagName = release.tag_name;
   </div>
   <div class="links">
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-windows-x64.zip`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-windows-x64.zip`
       >Windows</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-macos-universal.pkg`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-macos-universal.pkg`
       >Mac</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
+      href=`https://github.com/kaito-tokyo/live-backgroundremoval-lite/releases/download/${tagName}/live-backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
       >Ubuntu</a
     >
     <a

--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.6.0
+pkgver=1.7.0
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('ad965ddd2889c756ea994e95a8983c593a2c916e019600274cc11448f4d3375a')
+sha256sums=('f5b5043126fc5bca8f5c3e68e2925bbb4a9c727db65b40ee970200681237118d')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -15,6 +15,20 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.7.0" date="2025-09-30">
+      <description>
+        <p>🎉 <b>Release 1.7.0</b></p>
+        <ul>
+          <li>✨ <b>Plugin Renamed:</b> The plugin is now "Live Background Removal Lite" everywhere. All references, file names, documentation, and install paths updated for consistency.</li>
+          <li>📝 <b>License Upgrade:</b> Now licensed under GPL-3.0-or-later.</li>
+          <li>📚 <b>Documentation & Demo:</b> README and documentation improved, demo GIF added, all links and instructions updated.</li>
+          <li>🛠️ <b>Build & Packaging:</b> All manifests and build files updated to match the new name and version. CMake bundleId, website, and metadata updated.</li>
+          <li>🧩 <b>Codebase Modernization:</b> Copyright and license headers updated, redundant files removed.</li>
+          <li>🌍 <b>Localization:</b> Plugin and UI labels updated in all supported languages.</li>
+        </ul>
+        <p>Thank you for supporting Live Background Removal Lite! If you notice anything amiss after this big rename and license change, please open an issue.</p>
+      </description>
+    </release>
     <release version="1.6.0" date="2025-09-29">
       <description>
         <p>🎉 <b>Release 1.6.0</b></p>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-        tag: 1.6.0
-        commit: '6d7f6c7425f114064d365642ebecd48eb1e90917'
+        tag: 1.7.0
+        commit: '385a366fc3d4274d7be066487ceeccfe2c11e0bf'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
This pull request updates the project to version 1.7.0, focusing on a comprehensive renaming of the plugin to "Live Background Removal Lite" across all code, documentation, and packaging. It also updates licensing, improves documentation, and modernizes the codebase. Several build and packaging files are updated to reflect the new version and naming consistency.

**Release and Naming Consistency:**
* Updated all download URLs in `docs/src/pages/index.astro` to use the new `live-backgroundremoval-lite` prefix for release assets, ensuring consistency with the new plugin name.
* Updated Flatpak and Arch Linux packaging files to reference version 1.7.0 and the new repository tag and commit, aligning all packaging with the renamed plugin. [[1]](diffhunk://#diff-4b0948512d66c7b27414351292302f58d746ba437afbd8991cb6831ae5255a99L35-R36) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3)

**Build and Packaging Updates:**
* Updated the SHA256 checksum in the Arch Linux `PKGBUILD` to match the new release tarball for version 1.7.0.

**Documentation and Metadata:**
* Added a new release entry for version 1.7.0 in the Flatpak metainfo XML, detailing the rename, license upgrade, documentation improvements, build updates, codebase modernization, and localization changes.