### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "live-backgroundremoval-lite",
     "displayName": "Live Background Removal Lite",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "author": "Kaito Udagawa",
     "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
     "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request updates the version number of the `live-backgroundremoval-lite` package. No other changes are included.

* Updated the `version` field in `buildspec.json` from `1.7.0` to `1.8.0`.