### PR TITLE
Update Arch/Flatpak manifests for 1.8.1 release

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.8.0
+pkgver=1.8.1
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('493e078721518aae0dfd3be3c56f6a3fc75095137f6736fcd613511e7b96c93a')
+sha256sums=('8a4c92dc38398a57044854258bd36c2e160a00faabdd5b5d5d40db1e8bef0f52f')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('8a4c92dc38398a57044854258bd36c2e160a00faabdd5b5d5d40db1e8bef0f52f')
+sha256sums=('8a4c92dc38398a57044854258bd36c2e160a00faabdd5b5d540db1e8bef0f52f')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -15,6 +15,18 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.8.1" date="2025-10-02">
+      <description>
+        <p>🎉 <b>Release 1.8.1</b></p>
+        <ul>
+          <li>🛠 <b>Linux Packaging:</b> Arch Linux PKGBUILD now correctly declares <code>curl</code> as a dependency and updates version/checksums.</li>
+          <li>📦 <b>Flatpak Manifest:</b> Flatpak build and metainfo files now point to the correct version and commit for v1.8.1.</li>
+          <li>⚙️ <b>GitHub Actions:</b> Astro site deployment workflow triggers on PRs to <code>main</code> and tags, deploy job runs only for <code>main</code> or tags.</li>
+          <li>📝 <b>Docs & Process:</b> Minor instruction and manifest tweaks for update steps and file naming.</li>
+        </ul>
+        <p>Thank you to everyone who packages and maintains Live Background Removal Lite on Linux! If you spot any issues with builds or packaging, please open an issue or pull request.</p>
+      </description>
+    </release>
     <release version="1.8.0" date="2025-10-01">
       <description>
         <p>🎉 <b>Release 1.8.0</b></p>
@@ -86,17 +98,5 @@
       </description>
     </release>
   </releases>
-      <release version="1.8.1" date="2025-10-02">
-        <description>
-          <p>🎉 <b>Release 1.8.1</b></p>
-          <ul>
-            <li>🛠 <b>Linux Packaging:</b> Arch Linux PKGBUILD now correctly declares <code>curl</code> as a dependency and updates version/checksums.</li>
-            <li>📦 <b>Flatpak Manifest:</b> Flatpak build and metainfo files now point to the correct version and commit for v1.8.1.</li>
-            <li>⚙️ <b>GitHub Actions:</b> Astro site deployment workflow triggers on PRs to <code>main</code> and tags, deploy job runs only for <code>main</code> or tags.</li>
-            <li>📝 <b>Docs & Process:</b> Minor instruction and manifest tweaks for update steps and file naming.</li>
-          </ul>
-          <p>Thank you to everyone who packages and maintains Live Background Removal Lite on Linux! If you spot any issues with builds or packaging, please open an issue or pull request.</p>
-        </description>
-      </release>
   <content_rating type="oars-1.1" />
 </component>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -86,5 +86,17 @@
       </description>
     </release>
   </releases>
+      <release version="1.8.1" date="2025-10-02">
+        <description>
+          <p>🎉 <b>Release 1.8.1</b></p>
+          <ul>
+            <li>🛠 <b>Linux Packaging:</b> Arch Linux PKGBUILD now correctly declares <code>curl</code> as a dependency and updates version/checksums.</li>
+            <li>📦 <b>Flatpak Manifest:</b> Flatpak build and metainfo files now point to the correct version and commit for v1.8.1.</li>
+            <li>⚙️ <b>GitHub Actions:</b> Astro site deployment workflow triggers on PRs to <code>main</code> and tags, deploy job runs only for <code>main</code> or tags.</li>
+            <li>📝 <b>Docs & Process:</b> Minor instruction and manifest tweaks for update steps and file naming.</li>
+          </ul>
+          <p>Thank you to everyone who packages and maintains Live Background Removal Lite on Linux! If you spot any issues with builds or packaging, please open an issue or pull request.</p>
+        </description>
+      </release>
   <content_rating type="oars-1.1" />
 </component>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-        tag: 1.8.0
-        commit: '7b77f0f16fb13de264d2acdba3326bebf10c4342'
+        tag: 1.8.1
+        commit: '89e052b84a6ed4e6572e1d28a4ffb536806d56d3'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
Arch Linux PKGBUILD and Flatpak manifests updated for 1.8.1. Includes new version, checksums, tag, commit, and release notes.