### PR TITLE
Update manifests 1.8.2

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.8.1
+pkgver=1.8.2
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('8a4c92dc38398a57044854258bd36c2e160a00faabdd5b5d540db1e8bef0f52f')
+sha256sums=('64dceffdbb7bf42538589a4c272cc6ca5ede2cb9de02ca53bfe467467ab5bcae')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -33,6 +33,20 @@
         <ul>
           <li>✨ <b>Web & Docs Polish:</b> New icons, web app manifest, improved metadata, and PWA support for a professional experience.</li>
           <li>🔌 <b>Plugin Integration:</b> OBS plugin info now registered as <code>live_backgroundremoval_lite</code>. Consistent filter selection and documentation.</li>
+    <release version="1.8.2" date="2025-10-04">
+      <description>
+        <p>🎉 <b>Release 1.8.2</b></p>
+        <ul>
+          <li>🛠 <b>Refactored Plugin Properties:</b> Settings and runtime properties are now handled more cleanly, making it easier to adjust filtering and segmentation features.</li>
+          <li>🪟 <b>Debug Window Overhaul:</b> Uses atomic operations for better stability and responsiveness, especially when switching rendering contexts or updating previews.</li>
+          <li>🎥 <b>Rendering Context Updates:</b> Improved creation and switching of rendering contexts for smoother and more reliable video filtering.</li>
+          <li>🖼 <b>Texture Reader Reliability:</b> Smarter logic for copying and syncing textures, reducing errors and speeding up previews.</li>
+          <li>🧹 <b>Code Maintenance:</b> Files reorganized (splitting <code>Preset</code> into <code>PluginProperty</code> and <code>PluginConfig</code>) for clarity and future flexibility.</li>
+          <li>🧑‍💻 <b>Developer Notes:</b> New internal files (<code>PluginConfig.hpp</code>, <code>PluginProperty.hpp</code>), refined C++ code and memory management, and atomics for debug/render data objects.</li>
+        </ul>
+        <p>Thank you for using Live Background Removal Lite! If you run into any issues or have suggestions for future improvements, please open an issue or pull request. Happy streaming! 🚀</p>
+      </description>
+    </release>
           <li>📦 <b>Packaging:</b> Flatpak/Arch manifests updated for new version/tag/commit.</li>
           <li>🧹 <b>Code Clean-up:</b> Minor refactoring, removed unused files and obsolete registry entries.</li>
           <li>🛠 <b>Other Improvements:</b> Dynamic documentation/download URLs, new assets, and metadata integration.</li>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -15,6 +15,20 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.8.2" date="2025-10-04">
+      <description>
+        <p>🎉 <b>Release 1.8.2</b></p>
+        <ul>
+          <li>🛠 <b>Refactored Plugin Properties:</b> Settings and runtime properties are now handled more cleanly, making it easier to adjust filtering and segmentation features.</li>
+          <li>🪟 <b>Debug Window Overhaul:</b> Uses atomic operations for better stability and responsiveness, especially when switching rendering contexts or updating previews.</li>
+          <li>🎥 <b>Rendering Context Updates:</b> Improved creation and switching of rendering contexts for smoother and more reliable video filtering.</li>
+          <li>🖼 <b>Texture Reader Reliability:</b> Smarter logic for copying and syncing textures, reducing errors and speeding up previews.</li>
+          <li>🧹 <b>Code Maintenance:</b> Files reorganized (splitting <code>Preset</code> into <code>PluginProperty</code> and <code>PluginConfig</code>) for clarity and future flexibility.</li>
+          <li>🧑‍💻 <b>Developer Notes:</b> New internal files (<code>PluginConfig.hpp</code>, <code>PluginProperty.hpp</code>), refined C++ code and memory management, and atomics for debug/render data objects.</li>
+        </ul>
+        <p>Thank you for using Live Background Removal Lite! If you run into any issues or have suggestions for future improvements, please open an issue or pull request. Happy streaming! 🚀</p>
+      </description>
+    </release>
     <release version="1.8.1" date="2025-10-02">
       <description>
         <p>🎉 <b>Release 1.8.1</b></p>
@@ -33,20 +47,6 @@
         <ul>
           <li>✨ <b>Web & Docs Polish:</b> New icons, web app manifest, improved metadata, and PWA support for a professional experience.</li>
           <li>🔌 <b>Plugin Integration:</b> OBS plugin info now registered as <code>live_backgroundremoval_lite</code>. Consistent filter selection and documentation.</li>
-    <release version="1.8.2" date="2025-10-04">
-      <description>
-        <p>🎉 <b>Release 1.8.2</b></p>
-        <ul>
-          <li>🛠 <b>Refactored Plugin Properties:</b> Settings and runtime properties are now handled more cleanly, making it easier to adjust filtering and segmentation features.</li>
-          <li>🪟 <b>Debug Window Overhaul:</b> Uses atomic operations for better stability and responsiveness, especially when switching rendering contexts or updating previews.</li>
-          <li>🎥 <b>Rendering Context Updates:</b> Improved creation and switching of rendering contexts for smoother and more reliable video filtering.</li>
-          <li>🖼 <b>Texture Reader Reliability:</b> Smarter logic for copying and syncing textures, reducing errors and speeding up previews.</li>
-          <li>🧹 <b>Code Maintenance:</b> Files reorganized (splitting <code>Preset</code> into <code>PluginProperty</code> and <code>PluginConfig</code>) for clarity and future flexibility.</li>
-          <li>🧑‍💻 <b>Developer Notes:</b> New internal files (<code>PluginConfig.hpp</code>, <code>PluginProperty.hpp</code>), refined C++ code and memory management, and atomics for debug/render data objects.</li>
-        </ul>
-        <p>Thank you for using Live Background Removal Lite! If you run into any issues or have suggestions for future improvements, please open an issue or pull request. Happy streaming! 🚀</p>
-      </description>
-    </release>
           <li>📦 <b>Packaging:</b> Flatpak/Arch manifests updated for new version/tag/commit.</li>
           <li>🧹 <b>Code Clean-up:</b> Minor refactoring, removed unused files and obsolete registry entries.</li>
           <li>🛠 <b>Other Improvements:</b> Dynamic documentation/download URLs, new assets, and metadata integration.</li>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-          tag: 1.8.2
-          commit: 'cf90e1c9ba6fc0b7e031b6ffec63a797373ae100'
+        tag: 1.8.2
+        commit: 'cf90e1c9ba6fc0b7e031b6ffec63a797373ae100'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-        tag: 1.8.1
-        commit: '89e052b84a6ed4e6572e1d28a4ffb536806d56d3'
+          tag: 1.8.2
+          commit: 'cf90e1c9ba6fc0b7e031b6ffec63a797373ae100'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
This pull request updates the Live Background Removal Lite plugin to version 1.8.2 across Arch and Flatpak packaging. It includes metadata updates, improved plugin stability and maintainability, and reorganized code for future flexibility.

**Version and Source Updates:**

* Bumped `pkgver` in `PKGBUILD` to `1.8.2` and updated the corresponding source tarball and `sha256sums` to match the new release. [[1]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL13-R13)
* Updated Flatpak build manifest to use tag `1.8.2` and commit `cf90e1c9ba6fc0b7e031b6ffec63a797373ae100` for the plugin source.

**Release Metadata and Feature Improvements:**

* Added a detailed 1.8.2 release entry in the Flatpak metainfo XML, highlighting:
  - Refactored plugin properties for easier filtering/segmentation adjustments.
  - Debug window overhaul using atomic operations for better stability.
  - Improved rendering context management for smoother video filtering.
  - Enhanced texture reader reliability and preview speed.
  - Codebase maintenance: split `Preset` into `PluginProperty` and `PluginConfig`, reorganized files, and improved C++ code/memory management.