### PR TITLE
Bump version to 1.8.3

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,45 +1,45 @@
 {
-	"dependencies": {
-		"obs-studio": {
-			"version": "31.1.1",
-			"baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
-			"label": "OBS sources",
-			"hashes": {
-				"macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
-				"windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
-			}
-		},
-		"prebuilt": {
-			"version": "2025-07-11",
-			"baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-			"label": "Pre-Built obs-deps",
-			"hashes": {
-				"macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
-				"windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
-			}
-		},
-		"qt6": {
-			"version": "2025-07-11",
-			"baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-			"label": "Pre-Built Qt6",
-			"hashes": {
-				"macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
-				"windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
-			},
-			"debugSymbols": {
-				"windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
-			}
-		}
-	},
-	"platformConfig": {
-		"macos": {
-			"bundleId": "tokyo.kaito.live-backgroundremoval-lite"
-		}
-	},
-	"name": "live-backgroundremoval-lite",
-	"displayName": "Live Background Removal Lite",
-	"version": "1.8.3",
-	"author": "Kaito Udagawa",
-	"website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
-	"email": "umireon@kaito.tokyo"
+    "dependencies": {
+        "obs-studio": {
+            "version": "31.1.1",
+            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+            "label": "OBS sources",
+            "hashes": {
+                "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
+                "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
+            }
+        },
+        "prebuilt": {
+            "version": "2025-07-11",
+            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+            "label": "Pre-Built obs-deps",
+            "hashes": {
+                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
+                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
+            }
+        },
+        "qt6": {
+            "version": "2025-07-11",
+            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+            "label": "Pre-Built Qt6",
+            "hashes": {
+                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
+                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
+            },
+            "debugSymbols": {
+                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
+            }
+        }
+    },
+    "platformConfig": {
+        "macos": {
+            "bundleId": "tokyo.kaito.live-backgroundremoval-lite"
+        }
+    },
+    "name": "live-backgroundremoval-lite",
+    "displayName": "Live Background Removal Lite",
+    "version": "1.8.3",
+    "author": "Kaito Udagawa",
+    "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
+    "email": "umireon@kaito.tokyo"
 }

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,45 +1,45 @@
 {
-    "dependencies": {
-        "obs-studio": {
-            "version": "31.1.1",
-            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
-            "label": "OBS sources",
-            "hashes": {
-                "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
-                "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
-            }
-        },
-        "prebuilt": {
-            "version": "2025-07-11",
-            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-            "label": "Pre-Built obs-deps",
-            "hashes": {
-                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
-                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
-            }
-        },
-        "qt6": {
-            "version": "2025-07-11",
-            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-            "label": "Pre-Built Qt6",
-            "hashes": {
-                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
-                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
-            },
-            "debugSymbols": {
-                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
-            }
-        }
-    },
-    "platformConfig": {
-        "macos": {
-            "bundleId": "tokyo.kaito.live-backgroundremoval-lite"
-        }
-    },
-    "name": "live-backgroundremoval-lite",
-    "displayName": "Live Background Removal Lite",
-    "version": "1.8.2",
-    "author": "Kaito Udagawa",
-    "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
-    "email": "umireon@kaito.tokyo"
+	"dependencies": {
+		"obs-studio": {
+			"version": "31.1.1",
+			"baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+			"label": "OBS sources",
+			"hashes": {
+				"macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
+				"windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
+			}
+		},
+		"prebuilt": {
+			"version": "2025-07-11",
+			"baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+			"label": "Pre-Built obs-deps",
+			"hashes": {
+				"macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
+				"windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
+			}
+		},
+		"qt6": {
+			"version": "2025-07-11",
+			"baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+			"label": "Pre-Built Qt6",
+			"hashes": {
+				"macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
+				"windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
+			},
+			"debugSymbols": {
+				"windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
+			}
+		}
+	},
+	"platformConfig": {
+		"macos": {
+			"bundleId": "tokyo.kaito.live-backgroundremoval-lite"
+		}
+	},
+	"name": "live-backgroundremoval-lite",
+	"displayName": "Live Background Removal Lite",
+	"version": "1.8.3",
+	"author": "Kaito Udagawa",
+	"website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
+	"email": "umireon@kaito.tokyo"
 }


### PR DESCRIPTION
This pull request includes a minor version bump for the `live-backgroundremoval-lite` package, updating the version from 1.8.2 to 1.8.3. This change is likely for release or deployment purposes.
This pull request updates the version number of the `live-backgroundremoval-lite` project from 1.8.2 to 1.8.3 in the `buildspec.json` file. This is a minor change, likely indicating a small update or bugfix.