### PR TITLE
Update manifests 1.8.3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,8 +65,6 @@ To initiate a new release, the user will instruct Gemini to start the process (e
 7.  **Update Flatpak Package Manifest**:
     * **ACTION**: Add a new `<release>` element to `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`.
     * **ACTION**: The new release element should have the `version` and `date` attributes set to the new version and current date.
-    * **ACTION**: The description inside the release element should be a summary of the release notes from GitHub Releases.
-        You can get the body of release note by running `gh release view <tag>`.
     * **ACTION**: Update the `tag` field for the `live-backgroundremoval-lite` module in `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml` to the new version.
     * **ACTION**: Get the commit hash for the new tag by running `git rev-list -n 1 <new_version_tag>`.
     * **ACTION**: Update the `commit` field for the `live-backgroundremoval-lite` module in `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml` to the new commit hash.

--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.8.2
+pkgver=1.8.3
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('64dceffdbb7bf42538589a4c272cc6ca5ede2cb9de02ca53bfe467467ab5bcae')
+sha256sums=('6d7cd5ec635f2d2f8be60d84276f21d2abff8febd1124d6158e0da3bb5701108')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.8.3" date="2025-10-04" />
     <release version="1.8.2" date="2025-10-04" />
     <release version="1.8.1" date="2025-10-02" />
     <release version="1.8.0" date="2025-10-01" />

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml
@@ -35,8 +35,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-        tag: 1.8.2
-        commit: 'cf90e1c9ba6fc0b7e031b6ffec63a797373ae100'
+        tag: 1.8.3
+        commit: 'dc960a8135482e2458e762cb1f3932e0558fa24f'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
This pull request updates the packaging files to release version 1.8.3 of `live-backgroundremoval-lite` for both Arch and Flatpak distributions. The changes ensure that users will receive the latest version with the correct metadata and checksums.

**Arch packaging update:**

* Bumped the `pkgver` in `PKGBUILD` from `1.8.2` to `1.8.3` to reflect the new release.
* Updated the `sha256sums` in `PKGBUILD` to match the new source archive for version 1.8.3.

**Flatpak packaging update:**

* Added a new `<release>` element for version `1.8.3` with the current date in `com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`.
* Updated the `tag` and `commit` fields for the `live-backgroundremoval-lite` module in `com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml` to point to version `1.8.3` and its commit hash.

**Documentation update:**

* Removed instructions to include a summary of the release notes in the Flatpak manifest update step in `.github/copilot-instructions.md`.