### PR TITLE
Rename namespace to LiveBackgroundRemovalLite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,10 +86,10 @@ target_compile_definitions(
 target_sources(
   ${CMAKE_PROJECT_NAME}
   PRIVATE
+    src/Core/DebugWindow.cpp
     src/Core/MainPluginContext_c.cpp
     src/Core/MainPluginContext.cpp
     src/Core/RenderingContext.cpp
-    src/DebugWindow/DebugWindow.cpp
     src/SelfieSegmenter/SelfieSegmenter.cpp
     src/plugin-main.c
 )

--- a/src/Core/DebugWindow.cpp
+++ b/src/Core/DebugWindow.cpp
@@ -27,10 +27,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <QDebug>
 
 #include "../BridgeUtils/AsyncTextureReader.hpp"
-
-#include "../Core/MainPluginContext.h"
-#include "../Core/RenderingContext.hpp"
 #include "../BridgeUtils/ObsLogger.hpp"
+
+#include "MainPluginContext.h"
+#include "RenderingContext.hpp"
 
 using namespace KaitoTokyo::BridgeUtils;
 
@@ -63,7 +63,7 @@ const std::vector<std::string> r32fSubTextures = {
 } // namespace
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext, QWidget *parent)
 	: QDialog(parent),
@@ -298,5 +298,5 @@ void DebugWindow::updatePreview()
 	previewImageLabel->setPixmap(scaledPixmap);
 }
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/DebugWindow.hpp
+++ b/src/Core/DebugWindow.hpp
@@ -31,7 +31,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../BridgeUtils/ILogger.hpp"
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 class MainPluginContext;
 
@@ -78,5 +78,5 @@ private:
 	std::vector<std::uint8_t> bufferSubR8;
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/MainEffect.hpp
+++ b/src/Core/MainEffect.hpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../BridgeUtils/ObsUnique.hpp"
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 namespace main_effect_detail {
 
@@ -332,5 +332,5 @@ public:
 	}
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -24,18 +24,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 
-#include "../BridgeUtils/ObsLogger.hpp"
-
-#include "../DebugWindow/DebugWindow.hpp"
-#include "RenderingContext.hpp"
-#include "../BridgeUtils/ObsUnique.hpp"
 #include "../BridgeUtils/GsUnique.hpp"
+#include "../BridgeUtils/ObsLogger.hpp"
+#include "../BridgeUtils/ObsUnique.hpp"
+
+#include "DebugWindow.hpp"
+#include "RenderingContext.hpp"
 
 using namespace KaitoTokyo::BridgeUtils;
 using namespace KaitoTokyo::BridgeUtils;
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source,
 				     std::shared_future<std::string> _latestVersionFuture,
@@ -278,5 +278,5 @@ std::shared_ptr<RenderingContext> MainPluginContext::createRenderingContext(std:
 	return renderingContext;
 }
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/MainPluginContext.h
+++ b/src/Core/MainPluginContext.h
@@ -39,7 +39,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "PluginProperty.hpp"
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 class DebugWindow;
 class RenderingContext;
@@ -93,7 +93,7 @@ private:
 	std::shared_ptr<RenderingContext> createRenderingContext(std::uint32_t targetWidth, std::uint32_t targetHeight);
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo
 
 extern "C" {

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -29,7 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "PluginConfig.hpp"
 
 using namespace KaitoTokyo::BridgeUtils;
-using namespace KaitoTokyo::BackgroundRemovalLite;
+using namespace KaitoTokyo::LiveBackgroundRemovalLite;
 
 namespace {
 

--- a/src/Core/PluginConfig.hpp
+++ b/src/Core/PluginConfig.hpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../BridgeUtils/ObsUnique.hpp"
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 struct PluginConfig {
 	std::string latestVersionURL =
@@ -52,5 +52,5 @@ struct PluginConfig {
 	}
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 enum class FilterLevel : int {
 	Default = 0,
@@ -48,5 +48,5 @@ struct PluginProperty {
 	static float dbToLinearPow(float db) noexcept { return std::pow(10.0f, db / 10.0f); }
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -27,7 +27,7 @@ namespace {
 
 std::array<std::uint32_t, 4> getMaskRoiDimension(std::uint32_t width, std::uint32_t height)
 {
-	using namespace KaitoTokyo::BackgroundRemovalLite;
+	using namespace KaitoTokyo::LiveBackgroundRemovalLite;
 
 	double widthScale = static_cast<double>(SelfieSegmenter::INPUT_WIDTH) / static_cast<double>(width);
 	double heightScale = static_cast<double>(SelfieSegmenter::INPUT_HEIGHT) / static_cast<double>(height);
@@ -63,7 +63,7 @@ inline std::vector<unique_gs_texture_t> createReductionPyramid(std::uint32_t wid
 } // anonymous namespace
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger, const MainEffect &_mainEffect,
 				   const ncnn::Net &_selfieSegmenterNet, ThrottledTaskQueue &_selfieSegmenterTaskQueue,
@@ -276,5 +276,5 @@ obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
 	return frame;
 }
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -36,7 +36,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "PluginProperty.hpp"
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 class RenderingContext : public std::enable_shared_from_this<RenderingContext> {
 private:
@@ -118,5 +118,5 @@ private:
 	void kickSegmentationTask();
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/SelfieSegmenter/SelfieSegmenter.cpp
+++ b/src/SelfieSegmenter/SelfieSegmenter.cpp
@@ -36,7 +36,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #endif // defined(_M_ARM64) || defined(__aarch64__)
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 
 namespace {
 
@@ -222,5 +222,5 @@ void SelfieSegmenter::postprocess(std::vector<std::uint8_t> &mask) const
 	}
 }
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/src/SelfieSegmenter/SelfieSegmenter.hpp
+++ b/src/SelfieSegmenter/SelfieSegmenter.hpp
@@ -29,7 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <ncnn/net.h>
 
 namespace KaitoTokyo {
-namespace BackgroundRemovalLite {
+namespace LiveBackgroundRemovalLite {
 namespace SelfieSegmenterDetail {
 
 /**
@@ -102,5 +102,5 @@ private:
 	void postprocess(std::vector<std::uint8_t> &mask) const;
 };
 
-} // namespace BackgroundRemovalLite
+} // namespace LiveBackgroundRemovalLite
 } // namespace KaitoTokyo

--- a/tests/SelfieSegmenter/SelfieSegmenter_test.cpp
+++ b/tests/SelfieSegmenter/SelfieSegmenter_test.cpp
@@ -37,7 +37,7 @@ static bool load_jpg_bgra(const std::string &filename, std::vector<uint8_t> &out
 	return true;
 }
 
-using namespace KaitoTokyo::BackgroundRemovalLite;
+using namespace KaitoTokyo::LiveBackgroundRemovalLite;
 
 const char kParamPath[] = DATA_DIR "/models/mediapipe_selfie_segmentation.ncnn.param";
 const char kBinPath[] = DATA_DIR "/models/mediapipe_selfie_segmentation.ncnn.bin";


### PR DESCRIPTION
This pull request refactors the codebase to rename the namespace `BackgroundRemovalLite` to `LiveBackgroundRemovalLite` across all source, header, and test files. It also moves the `DebugWindow` implementation from `src/DebugWindow` to `src/Core`, updating all relevant includes and CMake configuration. These changes improve code organization and clarify the plugin's naming.

**Namespace refactor:**

* Renamed all instances of the namespace `BackgroundRemovalLite` to `LiveBackgroundRemovalLite` in source files, headers, and tests, including key plugin classes such as `MainPluginContext`, `RenderingContext`, `PluginConfig`, `PluginProperty`, `MainEffect`, and `SelfieSegmenter`. [[1]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L66-R66) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872R27-R38) [[3]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L66-R66) [[4]](diffhunk://#diff-67b13eb7df5901f564f81c5d34120e05f04645d451579a8deb82f53710879febL39-R39) [[5]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L32-R32) [[6]](diffhunk://#diff-032d4661922b1b3f64fce91a5dbb31c8823413ac4faf1e052c56cd57952b8294L40-R40)

**Code organization:**

* Moved `DebugWindow.cpp` and `DebugWindow.hpp` from `src/DebugWindow/` to `src/Core/`, updating all includes and references to reflect the new location. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR89-L92) [[2]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L30-R34) [[3]](diffhunk://#diff-05f204fc36a01c88a47e3e5288f34207f60adf00b6b16a3293ba431e69285232L34-R34)
* Updated CMake configuration in `CMakeLists.txt` to reference the new location of `DebugWindow.cpp` under `src/Core/`.

**Include and usage updates:**

* Adjusted include statements throughout the codebase to use the new paths and namespace for `DebugWindow` and other affected classes. [[1]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872R27-R38) [[2]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L30-R34)

**Namespace usage in implementation:**

* Updated all namespace closing statements and usages to match the new `LiveBackgroundRemovalLite` namespace in both implementation and header files. [[1]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L301-R301) [[2]](diffhunk://#diff-05f204fc36a01c88a47e3e5288f34207f60adf00b6b16a3293ba431e69285232L81-R81) [[3]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L335-R335) [[4]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L281-R281) [[5]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddL96-R96) [[6]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L32-R32) [[7]](diffhunk://#diff-9b04865c3d444b82207d1c8e288312153bb32920f98e41f2ad7303d507755fb0L55-R55) [[8]](diffhunk://#diff-121ed81dad6ffff38730c38361b7ad1ae41523af655c9cd9ffec232702b45dfdL51-R51) [[9]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L279-R279) [[10]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77L121-R121) [[11]](diffhunk://#diff-67b13eb7df5901f564f81c5d34120e05f04645d451579a8deb82f53710879febL225-R225) [[12]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L105-R105)

These changes are primarily organizational and do not affect runtime behavior but are important for maintainability and clarity.Changed all occurrences of the namespace BackgroundRemovalLite to LiveBackgroundRemovalLite across source, header, and test files. Also moved DebugWindow files from src/DebugWindow to src/Core and updated CMakeLists.txt accordingly for better organization and consistency.