### PR TITLE
Refactor atr

### DIFF
--- a/src/Core/DebugWindow.cpp
+++ b/src/Core/DebugWindow.cpp
@@ -120,43 +120,43 @@ void DebugWindow::videoRender()
 		auto currentTexture = previewTextureSelector->currentText();
 		if (currentTexture == textureBgrxOriginalImage) {
 			if (renderData->readerBgrx)
-				renderData->readerBgrx->stage(renderingContext->bgrxOriginalImage.get());
+				renderData->readerBgrx->stage(renderingContext->bgrxOriginalImage);
 		} else if (currentTexture == textureR32fOriginalGrayscale) {
 			if (renderData->readerR32f)
-				renderData->readerR32f->stage(renderingContext->r32fOriginalGrayscale.get());
+				renderData->readerR32f->stage(renderingContext->r32fOriginalGrayscale);
 		} else if (currentTexture == textureBgrxSegmenterInput) {
 			if (renderData->reader256Bgrx)
-				renderData->reader256Bgrx->stage(renderingContext->bgrxSegmenterInput.get());
+				renderData->reader256Bgrx->stage(renderingContext->bgrxSegmenterInput);
 		} else if (currentTexture == textureR8SegmentationMask) {
 			if (renderData->readerMaskRoiR8)
-				renderData->readerMaskRoiR8->stage(renderingContext->r8SegmentationMask.get());
+				renderData->readerMaskRoiR8->stage(renderingContext->r8SegmentationMask);
 		} else if (currentTexture == textureR8SubGFGuide) {
 			if (renderData->readerSubR8)
-				renderData->readerSubR8->stage(renderingContext->r8SubGFGuide.get());
+				renderData->readerSubR8->stage(renderingContext->r8SubGFGuide);
 		} else if (currentTexture == textureR8SubGFSource) {
 			if (renderData->readerSubR8)
-				renderData->readerSubR8->stage(renderingContext->r8SubGFSource.get());
+				renderData->readerSubR8->stage(renderingContext->r8SubGFSource);
 		} else if (currentTexture == textureR32fSubGFMeanGuide) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuide.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuide);
 		} else if (currentTexture == textureR32fSubGFMeanSource) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanSource.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanSource);
 		} else if (currentTexture == textureR16fSubGFMeanGuideSource) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuideSource.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuideSource);
 		} else if (currentTexture == textureR32fSubGFMeanGuideSq) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuideSq.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFMeanGuideSq);
 		} else if (currentTexture == textureR32fSubGFA) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFA.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFA);
 		} else if (currentTexture == textureR32fSubGFB) {
 			if (renderData->readerR32fSub)
-				renderData->readerR32fSub->stage(renderingContext->r32fSubGFB.get());
+				renderData->readerR32fSub->stage(renderingContext->r32fSubGFB);
 		} else if (currentTexture == textureR8GFResult) {
 			if (renderData->readerR8)
-				renderData->readerR8->stage(renderingContext->r8GFResult.get());
+				renderData->readerR8->stage(renderingContext->r8GFResult);
 		}
 	}
 }
@@ -228,12 +228,12 @@ void DebugWindow::updatePreview()
 			currentRenderData->readerBgrx->sync();
 			image = QImage(currentRenderData->readerBgrx->getBuffer().data(),
 				       currentRenderData->readerBgrx->width, currentRenderData->readerBgrx->height,
-				       currentRenderData->readerBgrx->getBufferLinesize(), QImage::Format_RGB32);
+				       currentRenderData->readerBgrx->dstLinesize, QImage::Format_RGB32);
 		} else if (std::find(r8Textures.begin(), r8Textures.end(), currentTextureStd) != r8Textures.end()) {
 			currentRenderData->readerR8->sync();
 			image = QImage(currentRenderData->readerR8->getBuffer().data(),
 				       currentRenderData->readerR8->width, currentRenderData->readerR8->height,
-				       currentRenderData->readerR8->getBufferLinesize(), QImage::Format_Grayscale8);
+				       currentRenderData->readerR8->dstLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r32fTextures.begin(), r32fTextures.end(), currentTextureStd) !=
 			   r32fTextures.end()) {
 			currentRenderData->readerR32f->sync();
@@ -252,21 +252,20 @@ void DebugWindow::updatePreview()
 			image = QImage(currentRenderData->reader256Bgrx->getBuffer().data(),
 				       currentRenderData->reader256Bgrx->width,
 				       currentRenderData->reader256Bgrx->height,
-				       currentRenderData->reader256Bgrx->getBufferLinesize(), QImage::Format_RGB32);
+				       currentRenderData->reader256Bgrx->dstLinesize, QImage::Format_RGB32);
 		} else if (std::find(r8MaskRoiTextures.begin(), r8MaskRoiTextures.end(), currentTextureStd) !=
 			   r8MaskRoiTextures.end()) {
 			currentRenderData->readerMaskRoiR8->sync();
 			image = QImage(currentRenderData->readerMaskRoiR8->getBuffer().data(),
 				       currentRenderData->readerMaskRoiR8->width,
 				       currentRenderData->readerMaskRoiR8->height,
-				       currentRenderData->readerMaskRoiR8->getBufferLinesize(),
-				       QImage::Format_Grayscale8);
+				       currentRenderData->readerMaskRoiR8->dstLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r8SubTextures.begin(), r8SubTextures.end(), currentTextureStd) !=
 			   r8SubTextures.end()) {
 			currentRenderData->readerSubR8->sync();
 			image = QImage(currentRenderData->readerSubR8->getBuffer().data(),
 				       currentRenderData->readerSubR8->width, currentRenderData->readerSubR8->height,
-				       currentRenderData->readerSubR8->getBufferLinesize(), QImage::Format_Grayscale8);
+				       currentRenderData->readerSubR8->dstLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r32fSubTextures.begin(), r32fSubTextures.end(), currentTextureStd) !=
 			   r32fSubTextures.end()) {
 			currentRenderData->readerR32fSub->sync();

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -267,7 +267,7 @@ void RenderingContext::videoRender()
 	}
 
 	if (needNewFrame && filterLevel >= FilterLevel::Segmentation) {
-		readerSegmenterInput.stage(bgrxSegmenterInput.get());
+		readerSegmenterInput.stage(bgrxSegmenterInput);
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the asynchronous GPU-to-CPU texture reading logic to improve type safety, buffer management, and code clarity. The most significant changes are in `AsyncTextureReader.hpp`, where the double-buffering pipeline is simplified and made more robust, and its usage is updated throughout the codebase to support these improvements.

### AsyncTextureReader improvements

* Refactored `AsyncTextureReader` to use a more robust double-buffering pipeline, replacing manual buffer stride management with a new `dstLinesize` member and simplifying the internal buffer logic. This includes making buffer access lock-free and updating the constructor and member variables for clarity and correctness.
* Replaced the `ScopedStageSurfMap` struct with a safer class that encapsulates mapping logic and provides accessor methods for mapped data and line size, improving error handling and encapsulation.

### API and usage consistency

* Updated the `stage` method to accept a `unique_gs_texture_t` reference instead of a raw pointer, improving type safety and consistency across all usage sites. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509R121-L234) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L270-R270) [[3]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L123-R159)
* Updated all calls to `stage` in `RenderingContext.cpp` and `DebugWindow.cpp` to pass the texture objects directly, removing unnecessary `.get()` calls for improved clarity and safety. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L270-R270) [[2]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L123-R159)

### Buffer stride usage

* Replaced all uses of the deprecated `getBufferLinesize()` with the new `dstLinesize` member in `DebugWindow.cpp` for correct buffer stride handling in image creation. [[1]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L231-R236) [[2]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L255-R268)

### Code cleanup

* Removed unused includes, reordered headers for clarity, and eliminated unnecessary public API methods from `AsyncTextureReader`. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509R21-L30) [[2]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509R121-L234)

Let me know if you want to discuss any specific part of the refactor or have questions about the new usage patterns!