### PR TITLE
Rename dstLinesize to bufferLinesize in texture reader

### DIFF
--- a/src/Core/DebugWindow.cpp
+++ b/src/Core/DebugWindow.cpp
@@ -228,12 +228,12 @@ void DebugWindow::updatePreview()
 			currentRenderData->readerBgrx->sync();
 			image = QImage(currentRenderData->readerBgrx->getBuffer().data(),
 				       currentRenderData->readerBgrx->width, currentRenderData->readerBgrx->height,
-				       currentRenderData->readerBgrx->dstLinesize, QImage::Format_RGB32);
+				       currentRenderData->readerBgrx->bufferLinesize, QImage::Format_RGB32);
 		} else if (std::find(r8Textures.begin(), r8Textures.end(), currentTextureStd) != r8Textures.end()) {
 			currentRenderData->readerR8->sync();
 			image = QImage(currentRenderData->readerR8->getBuffer().data(),
 				       currentRenderData->readerR8->width, currentRenderData->readerR8->height,
-				       currentRenderData->readerR8->dstLinesize, QImage::Format_Grayscale8);
+				       currentRenderData->readerR8->bufferLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r32fTextures.begin(), r32fTextures.end(), currentTextureStd) !=
 			   r32fTextures.end()) {
 			currentRenderData->readerR32f->sync();
@@ -252,20 +252,20 @@ void DebugWindow::updatePreview()
 			image = QImage(currentRenderData->reader256Bgrx->getBuffer().data(),
 				       currentRenderData->reader256Bgrx->width,
 				       currentRenderData->reader256Bgrx->height,
-				       currentRenderData->reader256Bgrx->dstLinesize, QImage::Format_RGB32);
+				       currentRenderData->reader256Bgrx->bufferLinesize, QImage::Format_RGB32);
 		} else if (std::find(r8MaskRoiTextures.begin(), r8MaskRoiTextures.end(), currentTextureStd) !=
 			   r8MaskRoiTextures.end()) {
 			currentRenderData->readerMaskRoiR8->sync();
 			image = QImage(currentRenderData->readerMaskRoiR8->getBuffer().data(),
 				       currentRenderData->readerMaskRoiR8->width,
 				       currentRenderData->readerMaskRoiR8->height,
-				       currentRenderData->readerMaskRoiR8->dstLinesize, QImage::Format_Grayscale8);
+				       currentRenderData->readerMaskRoiR8->bufferLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r8SubTextures.begin(), r8SubTextures.end(), currentTextureStd) !=
 			   r8SubTextures.end()) {
 			currentRenderData->readerSubR8->sync();
 			image = QImage(currentRenderData->readerSubR8->getBuffer().data(),
 				       currentRenderData->readerSubR8->width, currentRenderData->readerSubR8->height,
-				       currentRenderData->readerSubR8->dstLinesize, QImage::Format_Grayscale8);
+				       currentRenderData->readerSubR8->bufferLinesize, QImage::Format_Grayscale8);
 		} else if (std::find(r32fSubTextures.begin(), r32fSubTextures.end(), currentTextureStd) !=
 			   r32fSubTextures.end()) {
 			currentRenderData->readerR32fSub->sync();


### PR DESCRIPTION
This pull request refactors the naming of a key member variable in the `AsyncTextureReader` class and updates all related usages throughout the codebase to improve clarity. The variable `dstLinesize` has been renamed to `bufferLinesize`, and all references have been updated to use the new name. This change helps make the code more understandable and consistent.

Variable renaming and usage updates:

* Renamed the member variable `dstLinesize` to `bufferLinesize` in the `AsyncTextureReader` class, and updated its initialization and all internal usages to use the new name for clarity. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L141-R141) [[2]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L161-R163) [[3]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L202-R209)
* Updated all usages of `dstLinesize` to `bufferLinesize` in the `DebugWindow::updatePreview()` method, ensuring consistency in image buffer handling for different texture readers. [[1]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L231-R236) [[2]](diffhunk://#diff-554abd2731a267a23f9537f0dab6f96776b7eee94fecefaaa011750570aba2d3L255-R268)Replaces the dstLinesize member with bufferLinesize in AsyncTextureReader and updates all references in both AsyncTextureReader.hpp and DebugWindow.cpp for clarity and consistency.